### PR TITLE
Update `import` method to skip fields with only whitespace

### DIFF
--- a/src/TranslationService.php
+++ b/src/TranslationService.php
@@ -429,7 +429,11 @@ class TranslationService
                 $key = $row[1];
                 for ($i = 2; $i < count($header); $i++) {
                     $lang = $header[$i];
-                    $translations[$file][$key][$lang] = $row[$i] ?? '';
+                    $value = $row[$i] ?? '';
+                    if (trim($value) === '') {
+                        continue;
+                    }
+                    $translations[$file][$key][$lang] = $value;
                 }
             }
             fclose($handle);


### PR DESCRIPTION
* Add check to skip fields in the import if they are just whitespace
* Modify the assignment of translation values to include the check for whitespace