### PR TITLE
Add error handling for Illegal string offset errors in `updateTransla…

### DIFF
--- a/src/TranslationService.php
+++ b/src/TranslationService.php
@@ -513,7 +513,17 @@ class TranslationService
             foreach ($keys as $key => $langs) {
                 foreach ($langs as $lang => $value) {
                     try {
-                        $existing = $this->readExistingTranslations($langPath, $lang, $file);
+                        try {
+                            $existing = $this->readExistingTranslations($langPath, $lang, $file);
+                        } catch (\ErrorException $e) {
+                            if (strpos($e->getMessage(), 'Illegal string offset') !== false) {
+                                $this->logError("Illegal string offset error: " . $e->getMessage());
+                                echo "[Update] Illegal string offset error encountered. Continuing to next entry...\n";
+                                continue;
+                            } else {
+                                throw $e;
+                            }
+                        }
                         $nestedKey = $this->unflattenArray([$key => $value]);
                         $existing = array_merge_recursive($existing, $nestedKey);
                         $this->saveTranslationFile($langPath, $lang, $file, $existing);


### PR DESCRIPTION
…tions` method

* **Error Handling in `import` method**
  - Add try-catch block around `updateTranslations` method call to catch Illegal string offset errors
  - Log the error using `logError` method in the catch block
  - Continue to the next entry after logging the error

* **Error Handling in `updateTranslations` method**
  - Add try-catch block around `readExistingTranslations` method call to catch Illegal string offset errors
  - Log the error using `logError` method in the catch block